### PR TITLE
feat(macos): enable build, run, and Unity IPC on macOS

### DIFF
--- a/src-tauri/src/knowledge_index/embedding.rs
+++ b/src-tauri/src/knowledge_index/embedding.rs
@@ -1013,7 +1013,6 @@ fn manual_pooling_to_fastembed(pooling: ManualPoolingMode) -> Option<Pooling> {
     }
 }
 
-#[cfg(windows)]
 fn manual_pooling_from_fastembed(pooling: Pooling) -> ManualPoolingMode {
     match pooling {
         Pooling::Cls => ManualPoolingMode::Cls,

--- a/src-tauri/src/python_runtime.rs
+++ b/src-tauri/src/python_runtime.rs
@@ -263,7 +263,7 @@ pub fn ensure_python_shim_dir(python_path: &Path) -> Option<PathBuf> {
             use std::os::unix::fs::PermissionsExt;
             let mode = std::fs::Permissions::from_mode(0o755);
             let _ = std::fs::set_permissions(&python, mode.clone());
-            let _ = std::fs::set_permissions(&python3, mode);
+            let _ = std::fs::set_permissions(&python3, mode.clone());
             let _ = std::fs::set_permissions(&pip, mode.clone());
             let _ = std::fs::set_permissions(&pip3, mode);
         }

--- a/src-tauri/src/unity_bridge/mod.rs
+++ b/src-tauri/src/unity_bridge/mod.rs
@@ -127,7 +127,31 @@ fn get_pipe_name(project_path: &str) -> String {
         .replace('/', "_")
         .replace(':', "_")
         .replace(' ', "_");
-    format!(r"\\.\pipe\locus_unity_{}", sanitized)
+
+    #[cfg(target_os = "windows")]
+    {
+        format!(r"\\.\pipe\locus_unity_{}", sanitized)
+    }
+
+    // On macOS, Unity's Mono runtime maps NamedPipeServerStream(name, ...) to a
+    // Unix Domain Socket at `$TMPDIR/CoreFxPipe_<name>` (verified empirically with
+    // Unity 2021.3 on macOS 14). std::env::temp_dir() resolves $TMPDIR with fallback
+    // to /tmp, matching Mono's behavior — both processes must share the same $TMPDIR
+    // (true for non-sandboxed user processes on Mac).
+    #[cfg(target_os = "macos")]
+    {
+        std::env::temp_dir()
+            .join(format!("CoreFxPipe_locus_unity_{}", sanitized))
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    #[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
+    {
+        // Other Unix targets not yet supported; return a placeholder. Transport layer
+        // will fail at connect time with a clear error message.
+        format!("/tmp/locus_unity_{}_unsupported", sanitized)
+    }
 }
 
 pub fn is_unity_project(path: &str) -> bool {

--- a/src-tauri/src/unity_bridge/transport.rs
+++ b/src-tauri/src/unity_bridge/transport.rs
@@ -407,6 +407,418 @@ mod windows_impl {
     }
 }
 
+// ── macOS: Unix-domain-socket transport ──────────────────────────────
+//
+// Mirrors `windows_impl` but talks to Unity over a UDS at
+// `$TMPDIR/CoreFxPipe_locus_unity_<sanitized>` — see `get_pipe_name()` in
+// `unity_bridge/mod.rs`. Wire protocol (line-delimited JSON envelopes) is
+// transport-agnostic and reused unchanged.
+
+#[cfg(target_os = "macos")]
+mod unix_impl {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+    use std::{
+        collections::HashMap,
+        sync::{
+            atomic::{AtomicU64, Ordering},
+            OnceLock,
+        },
+    };
+    use tauri::{AppHandle, Emitter};
+    use tokio::{
+        io::{AsyncBufReadExt, AsyncWriteExt, BufReader, ReadHalf, WriteHalf},
+        net::UnixStream,
+        sync::oneshot,
+    };
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub(super) struct PipeEnvelope {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub id: Option<String>,
+
+        #[serde(default, rename = "reply_to", skip_serializing_if = "Option::is_none")]
+        pub reply_to: Option<String>,
+
+        #[serde(default, rename = "type")]
+        pub kind: String,
+
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub ok: Option<bool>,
+
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub message: Option<String>,
+
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub error: Option<String>,
+    }
+
+    struct UnityPipeConnection {
+        pipe_name: String,
+        writer: Mutex<Option<WriteHalf<UnixStream>>>,
+        pending: Mutex<HashMap<String, oneshot::Sender<Result<PipeEnvelope, String>>>>,
+        reader_abort: Mutex<Option<tokio::task::AbortHandle>>,
+    }
+
+    static CONNECTIONS: OnceLock<Mutex<HashMap<String, Arc<UnityPipeConnection>>>> =
+        OnceLock::new();
+    static EVENT_APP_HANDLE: OnceLock<AppHandle> = OnceLock::new();
+    static REQUEST_SEQ: AtomicU64 = AtomicU64::new(1);
+    const PIPE_WRITE_TIMEOUT: Duration = Duration::from_secs(10);
+
+    pub(super) fn set_event_app_handle(app_handle: AppHandle) {
+        let _ = EVENT_APP_HANDLE.set(app_handle);
+    }
+
+    fn connections() -> &'static Mutex<HashMap<String, Arc<UnityPipeConnection>>> {
+        CONNECTIONS.get_or_init(|| Mutex::new(HashMap::new()))
+    }
+
+    fn next_request_id() -> String {
+        format!("req-{}", REQUEST_SEQ.fetch_add(1, Ordering::Relaxed))
+    }
+
+    async fn open_client_with_retry(pipe_name: &str) -> Result<UnixStream, String> {
+        const MAX_RETRIES: u32 = 30;
+
+        let mut last_err = String::new();
+
+        for attempt in 0..MAX_RETRIES {
+            match UnixStream::connect(pipe_name).await {
+                Ok(stream) => return Ok(stream),
+                // NotFound: Unity hasn't bound the socket yet (Editor still starting).
+                // ConnectionRefused: socket exists but server isn't currently accepting
+                // (Unity restarting / between accept calls). Both are transient.
+                Err(e)
+                    if matches!(
+                        e.kind(),
+                        std::io::ErrorKind::NotFound | std::io::ErrorKind::ConnectionRefused
+                    ) && attempt + 1 < MAX_RETRIES =>
+                {
+                    last_err = format!("Failed to connect to Unity Editor ({}): {}", pipe_name, e);
+                    let delay_ms = (100 * (attempt as u64 + 1)).min(1_000);
+                    tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                }
+                Err(e) => {
+                    return Err(format!(
+                        "Failed to connect to Unity Editor ({}): {}",
+                        pipe_name, e
+                    ));
+                }
+            }
+        }
+
+        Err(last_err)
+    }
+
+    async fn remove_connection_if_same(pipe_name: &str, conn: &Arc<UnityPipeConnection>) {
+        let mut map = connections().lock().await;
+        if map
+            .get(pipe_name)
+            .map(|existing| Arc::ptr_eq(existing, conn))
+            .unwrap_or(false)
+        {
+            map.remove(pipe_name);
+        }
+    }
+
+    async fn fail_all_pending(conn: &Arc<UnityPipeConnection>, reason: String) {
+        let mut pending = conn.pending.lock().await;
+        for (_, tx) in pending.drain() {
+            let _ = tx.send(Err(reason.clone()));
+        }
+    }
+
+    async fn close_connection(conn: &Arc<UnityPipeConnection>, reason: String) {
+        fail_all_pending(conn, reason).await;
+
+        if let Some(abort) = conn.reader_abort.lock().await.take() {
+            abort.abort();
+        }
+
+        match conn.writer.try_lock() {
+            Ok(mut writer) => {
+                if let Some(mut writer) = writer.take() {
+                    let _ = writer.shutdown().await;
+                }
+            }
+            Err(_) => {
+                let conn = conn.clone();
+                tokio::spawn(async move {
+                    let mut writer = conn.writer.lock().await;
+                    if let Some(mut writer) = writer.take() {
+                        let _ = writer.shutdown().await;
+                    }
+                });
+            }
+        }
+    }
+
+    fn unsolicited_payload(env: &PipeEnvelope) -> serde_json::Value {
+        if let Some(message) = env.message.as_deref() {
+            if let Ok(value) = serde_json::from_str::<serde_json::Value>(message) {
+                return value;
+            }
+        }
+
+        serde_json::json!({
+            "message": env.message,
+            "error": env.error
+        })
+    }
+
+    fn handle_unsolicited_message(env: &PipeEnvelope) {
+        let event_name = env.kind.trim();
+        if event_name.is_empty() {
+            eprintln!(
+                "[Locus] unsolicited Unity message missing type: message={:?}, error={:?}",
+                env.message, env.error
+            );
+            return;
+        }
+
+        if let Some(app_handle) = EVENT_APP_HANDLE.get() {
+            let _ = app_handle.emit(event_name, unsolicited_payload(env));
+            return;
+        }
+
+        eprintln!(
+            "[Locus] unsolicited Unity message without app handle: type={}, message={:?}, error={:?}",
+            env.kind, env.message, env.error
+        );
+    }
+
+    async fn reader_loop(conn: Arc<UnityPipeConnection>, reader: ReadHalf<UnixStream>) {
+        let pipe_name = conn.pipe_name.clone();
+        let mut reader = BufReader::new(reader);
+        let mut line = String::new();
+
+        loop {
+            line.clear();
+
+            let n = match reader.read_line(&mut line).await {
+                Ok(n) => n,
+                Err(e) => {
+                    eprintln!("[Locus] pipe read error ({}): {}", pipe_name, e);
+                    break;
+                }
+            };
+
+            if n == 0 {
+                eprintln!("[Locus] pipe disconnected: {}", pipe_name);
+                break;
+            }
+
+            let trimmed = line.trim().trim_start_matches('\u{FEFF}');
+            if trimmed.is_empty() {
+                continue;
+            }
+
+            let env: PipeEnvelope = match serde_json::from_str(trimmed) {
+                Ok(v) => v,
+                Err(e) => {
+                    eprintln!(
+                        "[Locus] failed to parse pipe message ({}): {} | raw={}",
+                        pipe_name, e, trimmed
+                    );
+                    continue;
+                }
+            };
+
+            let reply_to = env
+                .reply_to
+                .clone()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty());
+
+            if let Some(reply_to) = reply_to {
+                let tx = {
+                    let mut pending = conn.pending.lock().await;
+                    pending.remove(&reply_to)
+                };
+
+                if let Some(tx) = tx {
+                    let _ = tx.send(Ok(env));
+                } else {
+                    eprintln!(
+                        "[Locus] received response for unknown request id: {}",
+                        reply_to
+                    );
+                }
+            } else {
+                handle_unsolicited_message(&env);
+            }
+        }
+
+        remove_connection_if_same(&pipe_name, &conn).await;
+        fail_all_pending(&conn, format!("Unity pipe disconnected: {}", pipe_name)).await;
+    }
+
+    async fn get_or_connect(project_path: &str) -> Result<Arc<UnityPipeConnection>, String> {
+        let pipe_name = get_pipe_name(project_path);
+
+        {
+            let map = connections().lock().await;
+            if let Some(conn) = map.get(&pipe_name) {
+                return Ok(conn.clone());
+            }
+        }
+
+        let client = open_client_with_retry(&pipe_name).await?;
+        let (reader, writer) = tokio::io::split(client);
+
+        let new_conn = Arc::new(UnityPipeConnection {
+            pipe_name: pipe_name.clone(),
+            writer: Mutex::new(Some(writer)),
+            pending: Mutex::new(HashMap::new()),
+            reader_abort: Mutex::new(None),
+        });
+
+        {
+            let mut map = connections().lock().await;
+            if let Some(existing) = map.get(&pipe_name) {
+                return Ok(existing.clone());
+            }
+            map.insert(pipe_name.clone(), new_conn.clone());
+        }
+
+        let reader_task = tokio::spawn(reader_loop(new_conn.clone(), reader));
+        *new_conn.reader_abort.lock().await = Some(reader_task.abort_handle());
+        Ok(new_conn)
+    }
+
+    async fn send_message_inner(
+        project_path: &str,
+        msg_type: &str,
+        message: &str,
+        timeout: Option<Duration>,
+    ) -> Result<PipeResponse, String> {
+        let conn = get_or_connect(project_path).await?;
+        let request_id = next_request_id();
+
+        let env = PipeEnvelope {
+            id: Some(request_id.clone()),
+            reply_to: None,
+            kind: msg_type.to_string(),
+            ok: None,
+            message: Some(message.to_string()),
+            error: None,
+        };
+
+        let json =
+            serde_json::to_string(&env).map_err(|e| format!("Serialization failed: {}", e))?;
+
+        let (tx, rx) = oneshot::channel();
+        {
+            let mut pending = conn.pending.lock().await;
+            pending.insert(request_id.clone(), tx);
+        }
+
+        let write_result = tokio::time::timeout(PIPE_WRITE_TIMEOUT, async {
+            let mut writer_guard = conn.writer.lock().await;
+            let writer = writer_guard
+                .as_mut()
+                .ok_or_else(|| "Unity pipe connection is closing".to_string())?;
+            writer
+                .write_all(json.as_bytes())
+                .await
+                .map_err(|e| format!("Pipe write failed: {}", e))?;
+            writer
+                .write_all(b"\n")
+                .await
+                .map_err(|e| format!("Newline write failed: {}", e))?;
+            writer
+                .flush()
+                .await
+                .map_err(|e| format!("Pipe flush failed: {}", e))
+        })
+        .await
+        .unwrap_or_else(|_| Err("Unity pipe write timed out".to_string()));
+
+        if let Err(err) = write_result {
+            {
+                let mut pending = conn.pending.lock().await;
+                pending.remove(&request_id);
+            }
+            remove_connection_if_same(&conn.pipe_name, &conn).await;
+            close_connection(&conn, err.clone()).await;
+            return Err(err);
+        }
+
+        let env = if let Some(timeout) = timeout {
+            match tokio::time::timeout(timeout, rx).await {
+                Ok(Ok(Ok(env))) => env,
+                Ok(Ok(Err(e))) => return Err(e),
+                Ok(Err(_)) => {
+                    return Err("Unity response failed: response channel closed".to_string())
+                }
+                Err(_) => {
+                    let err = "Unity response timed out".to_string();
+                    let mut pending = conn.pending.lock().await;
+                    pending.remove(&request_id);
+                    drop(pending);
+                    remove_connection_if_same(&conn.pipe_name, &conn).await;
+                    close_connection(&conn, err.clone()).await;
+                    return Err(err);
+                }
+            }
+        } else {
+            match rx.await {
+                Ok(Ok(env)) => env,
+                Ok(Err(e)) => return Err(e),
+                Err(_) => return Err("Unity response failed: response channel closed".to_string()),
+            }
+        };
+
+        Ok(PipeResponse {
+            ok: env.ok.unwrap_or(false),
+            error: env.error,
+            message: env.message,
+        })
+    }
+
+    pub async fn send_message_with_timeout(
+        project_path: &str,
+        msg_type: &str,
+        message: &str,
+        timeout: Duration,
+    ) -> Result<PipeResponse, String> {
+        send_message_inner(project_path, msg_type, message, Some(timeout)).await
+    }
+
+    pub async fn send_message_without_timeout(
+        project_path: &str,
+        msg_type: &str,
+        message: &str,
+    ) -> Result<PipeResponse, String> {
+        send_message_inner(project_path, msg_type, message, None).await
+    }
+
+    pub async fn send_message(
+        project_path: &str,
+        msg_type: &str,
+        message: &str,
+    ) -> Result<PipeResponse, String> {
+        send_message_with_timeout(project_path, msg_type, message, Duration::from_secs(35)).await
+    }
+
+    pub async fn disconnect_with_reason(project_path: &str, reason: &str) {
+        let pipe_name = get_pipe_name(project_path);
+        let conn = {
+            let mut map = connections().lock().await;
+            map.remove(&pipe_name)
+        };
+
+        if let Some(conn) = conn {
+            close_connection(&conn, reason.to_string()).await;
+        }
+    }
+
+    pub async fn disconnect(project_path: &str) {
+        disconnect_with_reason(project_path, "disconnected for recompile").await;
+    }
+}
+
 // ── Public dispatch ──────────────────────────────────────────────────
 
 #[cfg(target_os = "windows")]
@@ -414,7 +826,12 @@ pub fn set_event_app_handle(app_handle: tauri::AppHandle) {
     windows_impl::set_event_app_handle(app_handle);
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(target_os = "macos")]
+pub fn set_event_app_handle(app_handle: tauri::AppHandle) {
+    unix_impl::set_event_app_handle(app_handle);
+}
+
+#[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
 pub fn set_event_app_handle(_app_handle: tauri::AppHandle) {}
 
 #[cfg(target_os = "windows")]
@@ -445,32 +862,60 @@ pub async fn send_message_without_timeout(
     windows_impl::send_message_without_timeout(project_path, msg_type, message).await
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(target_os = "macos")]
+pub async fn send_message(
+    project_path: &str,
+    msg_type: &str,
+    message: &str,
+) -> Result<PipeResponse, String> {
+    unix_impl::send_message(project_path, msg_type, message).await
+}
+
+#[cfg(target_os = "macos")]
+pub async fn send_message_with_timeout(
+    project_path: &str,
+    msg_type: &str,
+    message: &str,
+    timeout: Duration,
+) -> Result<PipeResponse, String> {
+    unix_impl::send_message_with_timeout(project_path, msg_type, message, timeout).await
+}
+
+#[cfg(target_os = "macos")]
+pub async fn send_message_without_timeout(
+    project_path: &str,
+    msg_type: &str,
+    message: &str,
+) -> Result<PipeResponse, String> {
+    unix_impl::send_message_without_timeout(project_path, msg_type, message).await
+}
+
+#[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
 pub async fn send_message(
     _project_path: &str,
     _msg_type: &str,
     _message: &str,
 ) -> Result<PipeResponse, String> {
-    Err("Unity bridge is only supported on Windows (named pipes)".to_string())
+    Err("Unity bridge is only supported on Windows and macOS".to_string())
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
 pub async fn send_message_with_timeout(
     _project_path: &str,
     _msg_type: &str,
     _message: &str,
     _timeout: Duration,
 ) -> Result<PipeResponse, String> {
-    Err("Unity bridge is only supported on Windows (named pipes)".to_string())
+    Err("Unity bridge is only supported on Windows and macOS".to_string())
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
 pub async fn send_message_without_timeout(
     _project_path: &str,
     _msg_type: &str,
     _message: &str,
 ) -> Result<PipeResponse, String> {
-    Err("Unity bridge is only supported on Windows (named pipes)".to_string())
+    Err("Unity bridge is only supported on Windows and macOS".to_string())
 }
 
 #[cfg(target_os = "windows")]
@@ -483,8 +928,18 @@ pub async fn disconnect_with_reason(project_path: &str, reason: &str) {
     windows_impl::disconnect_with_reason(project_path, reason).await;
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(target_os = "macos")]
+pub async fn disconnect(project_path: &str) {
+    unix_impl::disconnect(project_path).await;
+}
+
+#[cfg(target_os = "macos")]
+pub async fn disconnect_with_reason(project_path: &str, reason: &str) {
+    unix_impl::disconnect_with_reason(project_path, reason).await;
+}
+
+#[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
 pub async fn disconnect(_project_path: &str) {}
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
 pub async fn disconnect_with_reason(_project_path: &str, _reason: &str) {}

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "build": {
+    "beforeBuildCommand": "bun run build"
+  },
+  "bundle": {
+    "targets": ["app", "dmg"]
+  }
+}


### PR DESCRIPTION
## Summary

Makes Locus buildable and runnable on macOS, including IPC to a Unity Editor over a Unix Domain Socket. Verified end-to-end against a Unity 2021.3 project on Apple Silicon.

This does **not** wire macOS into the official `release:installers` pipeline — that's a follow-up.

## What this PR enables

- `bun tauri dev` runs on macOS (after creating empty `src-tauri/gen/{licenses-bundle,ort-runtime}/` placeholders required by the main `bundle.resources` config).
- `bun tauri build --config src-tauri/tauri.macos.conf.json` produces an unsigned `.app` and `.dmg` (ad-hoc signed by the linker, sufficient for personal/dev use; Apple Developer ID still needed for distribution without Gatekeeper warnings).
- The desktop app talks to a Unity Editor on the same machine over the platform-correct UDS path (`$TMPDIR/CoreFxPipe_<name>`), matching Mono's `NamedPipeServerStream` behavior on macOS.

## Changes

- **`src-tauri/src/python_runtime.rs`** — add missing `.clone()` on `Permissions` in the Unix shim-creation path (real compile error never hit on Windows CI).
- **`src-tauri/src/knowledge_index/embedding.rs`** — remove an over-aggressive `#[cfg(windows)]` on `manual_pooling_from_fastembed`; the function is called from cross-platform `resolve_manual_pooling` and only uses `fastembed::Pooling`, so it is portable.
- **`src-tauri/src/unity_bridge/mod.rs`** — `get_pipe_name` gets a macOS branch returning `$TMPDIR/CoreFxPipe_locus_unity_<sanitized>` (plus a placeholder for other Unix targets).
- **`src-tauri/src/unity_bridge/transport.rs`** — new `unix_impl` module mirroring `windows_impl`, but built on `tokio::net::UnixStream`. The line-delimited JSON envelope protocol is reused unchanged; only the byte-stream substrate differs. Public dispatch (`send_message*`, `disconnect*`, `set_event_app_handle`) routes macOS to `unix_impl` and other non-Windows Unix to the existing error stub.
- **`src-tauri/tauri.macos.conf.json`** — minimal Tauri config override for macOS: skips the Windows-only `beforeBuildCommand` steps (`ort:bundle`, `python:bundle`, `git:bundle`) and replaces `targets: ["nsis"]` with `["app", "dmg"]`.

The real `locus_unity/` C# package, the Windows transport, and the main `tauri.conf.json` are untouched.

## Known follow-ups (not in this PR)

- **`release:installers` mac flavor** — `scripts/build-release-installers.mjs` is still NSIS-only. Adding a `mac` flavor would let a single command produce both Windows and macOS bundles.
- **Code signing + notarization** — only relevant if you want users to install without right-click→Open. Requires Apple Developer ID and `notarytool` credentials in CI.
- **`LocusEditorWindow.cs:1978-1982`** has two `user32.dll` `DllImport` declarations not guarded by `#if UNITY_EDITOR_WIN`; harmless at compile time (DllImport is a runtime binding) but would crash if those methods were actually called on macOS. Worth fencing for cleanliness.
- **Mono `NamedPipeServerStream` on macOS leaks the underlying socket FD across `Dispose()`** — confirmed empirically with a test probe. The real `LocusBridge.cs` will exhibit the same behavior under heavy Locus connect/disconnect churn on macOS. Right fix is to switch the server to raw `Socket(AddressFamily.Unix, ...)` on macOS. Not blocking for typical use.
- **UDS path length** is bounded by `sun_path` (104 bytes on macOS). Current sanitization works for short project paths; deeply nested paths (`~/Library/Application Support/...`) will exceed and require hash truncation on both Rust and C# sides.
- **aarch64 only** — Mac build currently only outputs arm64. Universal binary needs `--target universal-apple-darwin` and confirmation that `fastembed`/`ort` ship aarch64+x86_64 prebuilts.

## Test plan

- [x] `cargo check` passes on macOS aarch64.
- [x] `bun tauri dev` launches; Tauri main window opens; webview loads; Vue UI responds to invoke calls.
- [x] `cargo run --example unity_smoke` against a Unity project running a stub bridge: returns `ok=true` with echoed payload (added locally as a manual smoke test, not committed).
- [x] `bun tauri build --config src-tauri/tauri.macos.conf.json` produces `target/release/bundle/macos/locus.app` (105 MB) and `target/release/bundle/dmg/locus_0.2.15_aarch64.dmg` (44 MB) in ~3 min.
- [x] `open locus.app` launches; Keychain prompt for stored API key works; real Locus connects to a real `locus_unity` package in `~/locus_test` Unity 2021.3 project (`[Locus] Pipe client connected: locus_unity__Users_zuoyuanzhang_locus_test`).
- [ ] Windows build still passes (only mechanical impact: `transport.rs` dispatch table grew with macOS branches; `windows_impl` itself untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
