### PR TITLE
fix(macos): apply cross-platform build fixes from #62

### DIFF
--- a/src-tauri/src/knowledge_index/embedding.rs
+++ b/src-tauri/src/knowledge_index/embedding.rs
@@ -1013,7 +1013,6 @@ fn manual_pooling_to_fastembed(pooling: ManualPoolingMode) -> Option<Pooling> {
     }
 }
 
-#[cfg(windows)]
 fn manual_pooling_from_fastembed(pooling: Pooling) -> ManualPoolingMode {
     match pooling {
         Pooling::Cls => ManualPoolingMode::Cls,

--- a/src-tauri/src/python_runtime.rs
+++ b/src-tauri/src/python_runtime.rs
@@ -395,7 +395,7 @@ pub fn ensure_python_shim_dir(python_path: &Path) -> Option<PathBuf> {
             use std::os::unix::fs::PermissionsExt;
             let mode = std::fs::Permissions::from_mode(0o755);
             let _ = std::fs::set_permissions(&python, mode.clone());
-            let _ = std::fs::set_permissions(&python3, mode);
+            let _ = std::fs::set_permissions(&python3, mode.clone());
             let _ = std::fs::set_permissions(&pip, mode.clone());
             let _ = std::fs::set_permissions(&pip3, mode);
         }


### PR DESCRIPTION
## Summary

- remove the Windows-only guard from `manual_pooling_from_fastembed`
- retain `Permissions` for all Unix Python shim files
- preserve the original author metadata from #62 via cherry-pick

## Why

These two fixes remain applicable to the current codebase and unblock cross-platform compilation without changing Windows behavior.

Source: r1n7aro/Locus#62, commit `ac3c9af99d00b0af68729fc04934d84cd649ce8c`.

## Validation

- `git show --check` passed
- `bun run test`: 1480 passed, 6 existing failures; the same 6 failures reproduce on `origin/main` in the isolated clone
- `cargo check --manifest-path src-tauri/Cargo.toml`: compilation reached the Locus build script and stopped because the isolated clone lacks generated resource `src-tauri/gen/gh-runtime`
