### PR TITLE
fix(tool): show real source-file line numbers in edit diff previews

### DIFF
--- a/src-tauri/src/commands/diff.rs
+++ b/src-tauri/src/commands/diff.rs
@@ -96,14 +96,25 @@ pub async fn diff_text_for_large(
 }
 
 #[tauri::command]
+/// Compute diff hunks between two text blobs and optionally shift the
+/// reported line numbers onto a surrounding document.
+///
+/// `old_start_offset` and `new_start_offset` are 1-based line numbers in
+/// the surrounding document that correspond to the first line of `old_text`
+/// and `new_text` respectively. Pass `0` to keep the legacy behaviour where
+/// line numbers are relative to each input (1-based per string).
 pub async fn diff_strings(
     old_text: String,
     new_text: String,
     context_lines: Option<usize>,
+    old_start_offset: Option<usize>,
+    new_start_offset: Option<usize>,
 ) -> AppResult<Vec<DiffHunk>> {
     Ok(compute_hunks(
         &old_text,
         &new_text,
         context_lines.unwrap_or(3),
+        old_start_offset.filter(|n| *n > 0),
+        new_start_offset.filter(|n| *n > 0),
     ))
 }

--- a/src-tauri/src/diff/service.rs
+++ b/src-tauri/src/diff/service.rs
@@ -361,7 +361,7 @@ pub(crate) async fn build_file_diff_payload(
         };
         // Emit TextDiff BEFORE compute so UI shows progress during the work
         semantic::emit_diff_progress(app_handle, &profiler, DiffPhase::TextDiff, None);
-        let all_hunks = compute_hunks(&pair.old_content, &pair.new_content, context);
+        let all_hunks = compute_hunks(&pair.old_content, &pair.new_content, context, None, None);
         let stats = count_stats(&all_hunks);
         let hunks = if detail == DiffDetail::Preview {
             truncate_for_preview(all_hunks)
@@ -468,6 +468,6 @@ pub(crate) async fn compute_text_diff_on_demand(
         .max(pair.new_content.lines().count());
     let context = if request.full_context { total_lines } else { 3 };
 
-    let hunks = compute_hunks(&pair.old_content, &pair.new_content, context);
+    let hunks = compute_hunks(&pair.old_content, &pair.new_content, context, None, None);
     Ok(TextDiffResult { hunks })
 }

--- a/src-tauri/src/diff/text.rs
+++ b/src-tauri/src/diff/text.rs
@@ -20,7 +20,21 @@ fn normalize_for_text_diff(text: &str) -> Cow<'_, str> {
     }
 }
 
-pub fn compute_hunks(old: &str, new: &str, context: usize) -> Vec<DiffHunk> {
+/// Compute diff hunks between two text blobs.
+///
+/// `old_start_offset` and `new_start_offset` (both 1-based) shift the
+/// reported line numbers so callers can map the relative `old`/`new` line
+/// indices back to a surrounding document (e.g. an edit tool's preview,
+/// where `old`/`new` are the diffed snippet and the offset is the snippet's
+/// first source-file line number). Pass `None` to keep the legacy 1-based
+/// behaviour where line numbers are relative to each input.
+pub fn compute_hunks(
+    old: &str,
+    new: &str,
+    context: usize,
+    old_start_offset: Option<usize>,
+    new_start_offset: Option<usize>,
+) -> Vec<DiffHunk> {
     let old = normalize_for_text_diff(old);
     let new = normalize_for_text_diff(new);
     let old = old.as_ref();
@@ -37,6 +51,8 @@ pub fn compute_hunks(old: &str, new: &str, context: usize) -> Vec<DiffHunk> {
     } else {
         TextDiff::from_lines(old, new)
     };
+    let old_offset = old_start_offset.unwrap_or(1);
+    let new_offset = new_start_offset.unwrap_or(1);
     let mut hunks = Vec::new();
 
     for group in diff.grouped_ops(context) {
@@ -68,11 +84,11 @@ pub fn compute_hunks(old: &str, new: &str, context: usize) -> Vec<DiffHunk> {
                 let (kind, old_line_no, new_line_no) = match change.tag() {
                     ChangeTag::Equal => (
                         DiffLineKind::Context,
-                        old_idx.map(|i| i + 1),
-                        new_idx.map(|i| i + 1),
+                        old_idx.map(|i| i + old_offset),
+                        new_idx.map(|i| i + new_offset),
                     ),
-                    ChangeTag::Delete => (DiffLineKind::Delete, old_idx.map(|i| i + 1), None),
-                    ChangeTag::Insert => (DiffLineKind::Add, None, new_idx.map(|i| i + 1)),
+                    ChangeTag::Delete => (DiffLineKind::Delete, old_idx.map(|i| i + old_offset), None),
+                    ChangeTag::Insert => (DiffLineKind::Add, None, new_idx.map(|i| i + new_offset)),
                 };
 
                 lines.push(DiffLine {
@@ -85,14 +101,14 @@ pub fn compute_hunks(old: &str, new: &str, context: usize) -> Vec<DiffHunk> {
         }
 
         let old_start_1 = if old_start == usize::MAX {
-            1
+            old_offset
         } else {
-            old_start + 1
+            old_start + old_offset
         };
         let new_start_1 = if new_start == usize::MAX {
-            1
+            new_offset
         } else {
-            new_start + 1
+            new_start + new_offset
         };
 
         hunks.push(DiffHunk {
@@ -156,14 +172,14 @@ mod tests {
 
     #[test]
     fn compute_hunks_ignores_line_ending_only_changes() {
-        let hunks = compute_hunks("alpha\r\nbeta\r\ngamma\r\n", "alpha\nbeta\ngamma\n", 3);
+        let hunks = compute_hunks("alpha\r\nbeta\r\ngamma\r\n", "alpha\nbeta\ngamma\n", 3, None, None);
 
         assert!(hunks.is_empty());
     }
 
     #[test]
     fn compute_hunks_keeps_content_changes_when_line_endings_differ() {
-        let hunks = compute_hunks("alpha\r\nbeta\r\ngamma\r\n", "alpha\nBETA\ngamma\n", 3);
+        let hunks = compute_hunks("alpha\r\nbeta\r\ngamma\r\n", "alpha\nBETA\ngamma\n", 3, None, None);
         let stats = count_stats(&hunks);
         let deletes: Vec<&str> = hunks
             .iter()
@@ -194,7 +210,7 @@ mod tests {
             .collect::<String>();
 
         let started = std::time::Instant::now();
-        let hunks = compute_hunks(&old, &new, 3);
+        let hunks = compute_hunks(&old, &new, 3, None, None);
         let elapsed = started.elapsed();
 
         assert!(!hunks.is_empty());
@@ -203,5 +219,55 @@ mod tests {
             "large distinct diff took too long: {:?}",
             elapsed
         );
+    }
+
+    #[test]
+    fn compute_hunks_shifts_line_numbers_with_offsets() {
+        // Simulates the edit-tool case: old/new are a snippet that lives at
+        // source lines 42-45 in the surrounding document. The reported line
+        // numbers must reflect the surrounding document, not the snippet
+        // (which itself starts at 1).
+        let old = "alpha\nbeta\ngamma\n";
+        let new = "alpha\nBETA\ngamma\n";
+        let hunks = compute_hunks(old, new, 3, Some(42), Some(42));
+
+        let hunk = hunks.first().expect("expected one hunk");
+        assert_eq!(hunk.old_start, 43, "oldStart should be 42 + 1");
+        assert_eq!(hunk.new_start, 43, "newStart should be 42 + 1");
+
+        let deletes: Vec<Option<usize>> =
+            hunk.lines.iter().map(|l| l.old_line_no).collect();
+        let adds: Vec<Option<usize>> =
+            hunk.lines.iter().map(|l| l.new_line_no).collect();
+
+        // Old snippet lines 1..3 -> source 42..44 (alpha context, beta delete, gamma context).
+        assert_eq!(deletes, vec![Some(42), Some(43), Some(44)]);
+        // New snippet lines 1..3 -> source 42..44 (alpha context, BETA add, gamma context).
+        assert_eq!(adds, vec![Some(42), None, Some(43), Some(44)]);
+    }
+
+    #[test]
+    fn compute_hunks_one_offset_matches_legacy_one_based() {
+        // `Some(1)` reproduces the legacy 1-based per-string behaviour
+        // (the IPC layer maps `0` or `None` to `1` for the call site).
+        let hunks_none = compute_hunks("alpha\nbeta\ngamma\n", "alpha\nBETA\ngamma\n", 3, None, None);
+        let hunks_one = compute_hunks("alpha\nbeta\ngamma\n", "alpha\nBETA\ngamma\n", 3, Some(1), Some(1));
+
+        assert_eq!(hunks_none.len(), hunks_one.len());
+        for (a, b) in hunks_none.iter().zip(hunks_one.iter()) {
+            assert_eq!(a.old_start, b.old_start);
+            assert_eq!(a.new_start, b.new_start);
+            let a_line_nos: Vec<_> = a
+                .lines
+                .iter()
+                .map(|l| (l.old_line_no, l.new_line_no))
+                .collect();
+            let b_line_nos: Vec<_> = b
+                .lines
+                .iter()
+                .map(|l| (l.old_line_no, l.new_line_no))
+                .collect();
+            assert_eq!(a_line_nos, b_line_nos);
+        }
     }
 }

--- a/src/components/ToolCallBlock.vue
+++ b/src/components/ToolCallBlock.vue
@@ -270,7 +270,9 @@ const editDiffData = computed((): EditDiffResult | null => {
   }
 });
 
-// Compute diff payloads for each edit item using backend diff_strings
+// Compute diff payloads for each edit item using backend diff_strings.
+// `item.startLine` is the source-file line where the oldStr snippet starts;
+// newStr replaces oldStr in place, so its source line offset is the same.
 const editDiffPayloads = ref<Map<number, FileDiffPayload>>(new Map());
 
 watch(editDiffData, async (data) => {
@@ -279,7 +281,14 @@ watch(editDiffData, async (data) => {
   for (let i = 0; i < data.items.length; i++) {
     const item = data.items[i];
     try {
-      const hunks = await diffStrings(item.oldStr, item.newStr, 3);
+      const sourceStartLine = item.startLine > 0 ? item.startLine : undefined;
+      const hunks = await diffStrings(
+        item.oldStr,
+        item.newStr,
+        3,
+        sourceStartLine,
+        sourceStartLine,
+      );
       const additions = hunks.reduce((sum, h) => sum + h.lines.filter(l => l.kind === "add").length, 0);
       const deletions = hunks.reduce((sum, h) => sum + h.lines.filter(l => l.kind === "delete").length, 0);
       const payload: FileDiffPayload = {

--- a/src/services/diff.ts
+++ b/src/services/diff.ts
@@ -124,11 +124,25 @@ export async function diffStrings(
   oldText: string,
   newText: string,
   contextLines?: number,
+  /**
+   * 1-based line number in the surrounding document that corresponds to
+   * the first line of `oldText`. When omitted (or 0), line numbers stay
+   * relative to `oldText` itself.
+   */
+  oldStartOffset?: number,
+  /**
+   * Same as `oldStartOffset` but for `newText`. When `oldText` and `newText`
+   * replace each other in place (the edit-tool case), pass the same value
+   * for both.
+   */
+  newStartOffset?: number,
 ): Promise<DiffHunk[]> {
   return ipcInvoke<DiffHunk[]>("diff_strings", {
     oldText,
     newText,
     contextLines: contextLines ?? null,
+    oldStartOffset: oldStartOffset ?? null,
+    newStartOffset: newStartOffset ?? null,
   });
 }
 


### PR DESCRIPTION
The chat transcript's edit tool block expanded two side-by-side diffs
(an old / new pair) with line numbers coming from `FileDiffViewer` plus a
fallback `edit-diff-code` renderer. Both panels used `diffStrings` to
build a `FileDiffPayload`, but `diffStrings` was called without any
source-file offset, so the reported `oldStart` / `newStart` /
`oldLineNo` / `newLineNo` were 1-based line numbers inside the
old/new snippet itself — not the surrounding file. The fallback panel
already used the source-file start line (parsed from the tool output's
`[lines:N]` marker) so the two branches disagreed.

Wire the source-file start line through the diff pipeline so the
`FileDiffViewer` branch matches the fallback:

- `compute_hunks` (Rust) and the `diff_strings` Tauri command now take
  optional 1-based `oldStartOffset` / `newStartOffset` parameters that
  shift the reported line numbers onto a surrounding document. `None`
  (or `0` over IPC) preserves the legacy 1-based-per-string behaviour.
- The two existing `compute_hunks` callers in `diff::service` pass
  `None, None` (they diff full file contents where line numbers are
  already document-relative).
- `diffStrings` (TS) and `ToolCallBlock` forward `item.startLine` (the
  source-file line of the oldStr snippet) for both the old and new
  offsets, since newStr replaces oldStr in place. The knowledge-tool
  preview keeps calling without offsets (its before/after is a full
  document, so internal line numbers are already document-relative).

Tests: added `compute_hunks_shifts_line_numbers_with_offsets` and
`compute_hunks_one_offset_matches_legacy_one_based` to lock the offset
arithmetic in `diff::text::tests`.

Design-by: amostalong@126.com
Co-authored-by: deepseek-v4-flash
