### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,4 +148,4 @@ This project is a free and open-source tool for the Unity Editor, and is not aff
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=r1n7aro/Locus&type=Date)](https://www.star-history.com/#r1n7aro/Locus&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=r1n7aro/Locus&type=Date)](https://star-history.dera.page/#r1n7aro/Locus&Date)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -148,4 +148,4 @@ bun run release:installers
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=r1n7aro/Locus&type=Date)](https://www.star-history.com/#r1n7aro/Locus&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=r1n7aro/Locus&type=Date)](https://star-history.dera.page/#r1n7aro/Locus&Date)


### PR DESCRIPTION
The star history chart in the README is currently broken due to restrictions on the stargazer API, so the image does not render and the surrounding link does not resolve. This PR updates both the English and Chinese README to point at the working star history service so the chart renders again.